### PR TITLE
Fix stale fitter object after burst selection without recomputing FRET

### DIFF
--- a/fretbursts/burst_plot.py
+++ b/fretbursts/burst_plot.py
@@ -991,7 +991,8 @@ def hist_burst_data(
         bext.bursts_fitter(d, burst_data=data_name, weights=weights,
                            gamma=gamma, add_naa=add_naa)
 
-    fitter = d[fitter_name]
+    # fitter_name is only a attribute of Data, not a key in the dictionary
+    fitter = getattr(d, fitter_name)
     fitter.histogram(binwidth=binwidth, bins=bins, verbose=verbose)
     if pdf:
         ylabel('PDF')

--- a/fretbursts/burstlib_ext.py
+++ b/fretbursts/burstlib_ext.py
@@ -412,10 +412,10 @@ def bursts_fitter(dx, burst_data='E', save_fitter=True,
         if model is not None:
             fitter.fit_histogram(model=model, verbose=verbose)
     if save_fitter:
-        dx.add(
-            **{burst_data+'_fitter': fitter,
-               burst_data+'_weights': (weights, float(gamma), add_naa)}
-              )
+        # Save fitter variables as normal attributes (not with Data.add)
+        # so they are not copied when copying Data (e.g. burst selection)
+        setattr(dx, burst_data + '_fitter', fitter)
+        setattr(dx, burst_data + '_weights', (weights, float(gamma), add_naa))
     return fitter
 
 def _get_bg_distrib_erlang(d, ich=0, m=10, ph_sel=Ph_sel('all'),

--- a/fretbursts/tests/test_burstlib.py
+++ b/fretbursts/tests/test_burstlib.py
@@ -597,9 +597,10 @@ def test_burst_selection_nocorrections(data):
     """Test burst selection with uncorrected bursts.
     """
     d = data
-    d.burst_search(nofret=True)
+    d.burst_search(computefret=False)
     d.calc_fret(count_ph=True, corrections=False)
-    ds1 = d.select_bursts(select_bursts.size, th1=20, th2=100, nofret=True)
+    ds1 = d.select_bursts(select_bursts.size, th1=20, th2=100,
+                          computefret=False)
     ds2 = d.select_bursts(select_bursts.size, th1=20, th2=100)
     ds2.calc_ph_num()
     ds2.calc_fret(corrections=False)


### PR DESCRIPTION
This addresses #34.

The fitter objects inside `Data` (`Data.E_fitter`, `Data.S_fitter`, etc) are now simple attributes and are not added to the class dictionary anymore. In this way when copying `Data`, selecting bursts or creating a new `Data` variable using `Data(**old_data)`, the fitter object are not passed through.

Also I renamed the keyword argument `nofret` to `computefret`. In general negations in boolean variable names are not a good idea (think `nofret=False`) because they force users to mentally do 2 negations.