### PR TITLE
Implement and test Bursts.recompute_* methods

### DIFF
--- a/fretbursts/burstlib.py
+++ b/fretbursts/burstlib.py
@@ -1674,7 +1674,7 @@ class Data(DataContainer):
             if burstarray.size > 1:
                 bursts = bslib.Bursts(burstarray)
                 if compact:
-                    bursts = bursts.recompute_times(ph)
+                    bursts.recompute_times(ph, out=bursts)
             else:
                 bursts = bslib.Bursts.empty()
             mburst.append(bursts)
@@ -1714,7 +1714,7 @@ class Data(DataContainer):
                 data = np.vstack(burstarray_ch_list)
                 bursts = bslib.Bursts(data)
                 if compact:
-                    bursts = bursts.recompute_times(ph)
+                    bursts.recompute_times(ph, out=bursts)
             else:
                 bursts = bslib.Bursts.empty()
             MBurst.append(bursts)

--- a/fretbursts/burstlib.py
+++ b/fretbursts/burstlib.py
@@ -1652,7 +1652,7 @@ class Data(DataContainer):
                  rate_th=rate_th)
 
     def _burst_search_rate(self, m, L, min_rate_cps, ph_sel=Ph_sel('all'),
-                           compact=False, index_all=True, verbose=True,
+                           compact=False, index_allph=True, verbose=True,
                            pure_python=False):
         """Compute burst search using a fixed minimum photon rate.
 
@@ -1679,11 +1679,11 @@ class Data(DataContainer):
                 bursts = bslib.Bursts.empty()
             mburst.append(bursts)
         self.add(mburst=mburst, rate_th=Min_rate_cps, T=T_clk*self.clk_p)
-        if ph_sel != Ph_sel('all') and index_all:
+        if ph_sel != Ph_sel('all') and index_allph:
             self._fix_mburst_from(ph_sel=ph_sel)
 
     def _burst_search_TT(self, m, L, ph_sel=Ph_sel('all'), verbose=True,
-                         compact=False, index_all=True, pure_python=False,
+                         compact=False, index_allph=True, pure_python=False,
                          mute=False):
         """Compute burst search with params `m`, `L` on ph selection `ph_sel`
 
@@ -1720,7 +1720,7 @@ class Data(DataContainer):
             MBurst.append(bursts)
 
         self.add(mburst=MBurst)
-        if ph_sel != Ph_sel('all') and index_all:
+        if ph_sel != Ph_sel('all') and index_allph:
             # Convert the burst data to be relative to ph_times_m.
             # Convert both Lim/Ph_p and mburst, as they are both needed
             # to compute `.bp`.
@@ -1740,7 +1740,7 @@ class Data(DataContainer):
         pprint('[DONE]\n', mute)
 
     def burst_search(self, L=None, m=10, F=6., P=None, min_rate_cps=None,
-                     ph_sel=Ph_sel('all'), compact=False, index_all=True,
+                     ph_sel=Ph_sel('all'), compact=False, index_allph=True,
                      computefret=True, max_rate=False, dither=False,
                      pure_python=False, verbose=False, mute=False):
         """Performs a burst search with specified parameters.
@@ -1778,8 +1778,13 @@ class Data(DataContainer):
             ph_sel (Ph_sel object): object defining the photon selection
                 used for burst search. Default: all photons.
                 See :mod:`fretbursts.ph_sel` for details.
-            pure_python (bool): if True, uses the pure python functions even
-                when the optimized Cython functions are available.
+            compact (bool): if True, a photon selection of only one excitation
+                period is required and the timestamps are "compacted" by
+                removing the "gaps" between each excitation period.
+            index_allph (bool): if True (default), the indexes of burst start
+                and stop (`istart`, `istop`) are relative to the full
+                timestamp array. If False, the indexes are relative to
+                timestamps selected by the `ph_sel` argument.
             computefret (bool): if True (default) compute donor and acceptor
                 counts, apply corrections (background, leakage, direct
                 excitation) and compute E (and S). If False, skip all these
@@ -1789,6 +1794,8 @@ class Data(DataContainer):
                 (default) skip this step.
             dither (bool): whether to apply dithering corrections to burst
                 counts. See :meth:`Data.dither`.
+            pure_python (bool): if True, uses the pure python functions even
+                when the optimized Cython functions are available.
 
         Note:
             when using `P` or `F` the background rates are needed, so
@@ -1810,14 +1817,14 @@ class Data(DataContainer):
             # Saves rate_th in self
             self._burst_search_rate(m=m, L=L, min_rate_cps=min_rate_cps,
                                     ph_sel=ph_sel, compact=compact,
-                                    index_all=index_all,
+                                    index_allph=index_allph,
                                     verbose=verbose, pure_python=pure_python)
         else:
             # Compute TT, saves P and F in self
             self._calc_T(m=m, P=P, F=F, ph_sel=ph_sel)
             # Use TT and compute mburst
             self._burst_search_TT(L=L, m=m, ph_sel=ph_sel, compact=compact,
-                                  index_all=index_all, verbose=verbose,
+                                  index_allph=index_allph, verbose=verbose,
                                   pure_python=pure_python, mute=mute)
         pprint("[DONE]\n", mute)
 

--- a/fretbursts/burstlib.py
+++ b/fretbursts/burstlib.py
@@ -1735,7 +1735,7 @@ class Data(DataContainer):
 
         for bursts, mask in zip(self.mburst,
                                 self.iter_ph_masks(ph_sel=ph_sel)):
-            bursts.recompute_index_expand(mask)
+            bursts.recompute_index_expand(mask, out=bursts)
 
         pprint('[DONE]\n', mute)
 

--- a/fretbursts/burstlib.py
+++ b/fretbursts/burstlib.py
@@ -1652,7 +1652,8 @@ class Data(DataContainer):
                  rate_th=rate_th)
 
     def _burst_search_rate(self, m, L, min_rate_cps, ph_sel=Ph_sel('all'),
-                           compact=False, verbose=True, pure_python=False):
+                           compact=False, index_all=True, verbose=True,
+                           pure_python=False):
         """Compute burst search using a fixed minimum photon rate.
 
         Arguments:
@@ -1678,11 +1679,12 @@ class Data(DataContainer):
                 bursts = bslib.Bursts.empty()
             mburst.append(bursts)
         self.add(mburst=mburst, rate_th=Min_rate_cps, T=T_clk*self.clk_p)
-        if ph_sel != Ph_sel('all'):
+        if ph_sel != Ph_sel('all') and index_all:
             self._fix_mburst_from(ph_sel=ph_sel)
 
     def _burst_search_TT(self, m, L, ph_sel=Ph_sel('all'), verbose=True,
-                         compact=False, pure_python=False, mute=False):
+                         compact=False, index_all=True, pure_python=False,
+                         mute=False):
         """Compute burst search with params `m`, `L` on ph selection `ph_sel`
 
         Requires the list of arrays `self.TT` with the max time-thresholds in
@@ -1718,7 +1720,7 @@ class Data(DataContainer):
             MBurst.append(bursts)
 
         self.add(mburst=MBurst)
-        if ph_sel != Ph_sel('all'):
+        if ph_sel != Ph_sel('all') and index_all:
             # Convert the burst data to be relative to ph_times_m.
             # Convert both Lim/Ph_p and mburst, as they are both needed
             # to compute `.bp`.
@@ -1738,7 +1740,7 @@ class Data(DataContainer):
         pprint('[DONE]\n', mute)
 
     def burst_search(self, L=None, m=10, F=6., P=None, min_rate_cps=None,
-                     ph_sel=Ph_sel('all'), compact=False,
+                     ph_sel=Ph_sel('all'), compact=False, index_all=True,
                      computefret=True, max_rate=False, dither=False,
                      pure_python=False, verbose=False, mute=False):
         """Performs a burst search with specified parameters.
@@ -1808,14 +1810,15 @@ class Data(DataContainer):
             # Saves rate_th in self
             self._burst_search_rate(m=m, L=L, min_rate_cps=min_rate_cps,
                                     ph_sel=ph_sel, compact=compact,
+                                    index_all=index_all,
                                     verbose=verbose, pure_python=pure_python)
         else:
             # Compute TT, saves P and F in self
             self._calc_T(m=m, P=P, F=F, ph_sel=ph_sel)
             # Use TT and compute mburst
             self._burst_search_TT(L=L, m=m, ph_sel=ph_sel, compact=compact,
-                                  verbose=verbose, pure_python=pure_python,
-                                  mute=mute)
+                                  index_all=index_all, verbose=verbose,
+                                  pure_python=pure_python, mute=mute)
         pprint("[DONE]\n", mute)
 
         pprint(" - Calculating burst periods ...", mute)

--- a/fretbursts/burstsearch/burstsearchlib.py
+++ b/fretbursts/burstsearch/burstsearchlib.py
@@ -449,7 +449,7 @@ class Bursts(object):
         """
         newbursts = self.copy()
         newbursts.start = times[self.istart]
-        newbursts.stop = times[self.istart]
+        newbursts.stop = times[self.istop]
         return newbursts
 
     def recompute_index_expand(self, mask):

--- a/fretbursts/burstsearch/burstsearchlib.py
+++ b/fretbursts/burstsearch/burstsearchlib.py
@@ -477,36 +477,32 @@ class Bursts(object):
         self.istop = index[mask][self.istop]
         return self
 
-    def recompute_index_reduce(self, mask):
+    def recompute_index_reduce(self, times_reduced):
         """Recompute istart and istop on reduced timestamps selected by `mask`.
-
-        This is useful probably only for testing the inverse transformation
-        of :meth:`recompute_index_expand`.
 
         This method returns a new Bursts object with same start and stop times
         and recomputed istart and istop. Old istart, istop are assumed to
         be index of a "full" timestamps array of size `mask.size`. New istart,
-        istop are computed to be index of a reduced array `timestamps[mask]`.
+        istop are computed to be index of the reduced timestamps array
+        `timestamps_reduced`.
 
         Note: it is required that all the start and stop times are
         also contained in the reduced timestamps selection.
 
+        This method is the inverse of :meth:`recompute_index_expand`.
+
         Arguments:
-            mask (bool array): boolean mask defining the timestamp selection
-                on which the new istart and istop are computed.
+            times_reduced (array): array of selected timestamps used to
+                compute the new istart and istop. This array needs to be
+                a sub-set of the original timestamps array.
 
         Returns:
             A new Bursts object with recomputed istart/istop times.
         """
         newbursts = self.copy()
-        ## Untested, to be checked
-        newbursts.istart = np.nonzero(mask[self.istart])[0]
-        newbursts.istop = np.nonzero(mask[self.istop])[0]
-
-        # Check that we are not missing any start or stop index
-        assert newbursts.istart.size == self.istart.size
-        assert newbursts.istop.size == self.istop.size
-
+        for i, burst in enumerate(newbursts):
+            newbursts[i].istart = np.nonzero(times_reduced == burst.start)[0]
+            newbursts[i].istop = np.nonzero(times_reduced == burst.stop)[0]
         return newbursts
 
     def and_gate(self, bursts2):

--- a/fretbursts/burstsearch/burstsearchlib.py
+++ b/fretbursts/burstsearch/burstsearchlib.py
@@ -534,22 +534,21 @@ class Bursts(object):
 
         # Go through the timestamps searching for start
         # and stop of each burst in order
-        times_reducedm = memoryview(times_reduced)
         it = 0
         for ib, burst in enumerate(self):
             startfound = False
             while not startfound:
-                if times_reducedm[it] == burst.start:
+                if times_reduced[it] == burst.start:
                     out[ib].istart = it
                     startfound = True
                 it += 1
             it_saved = it
             stopfound = False
             while not stopfound:
-                if times_reducedm[it] == burst.stop:
+                if times_reduced[it] == burst.stop:
                     # there may be repeated timestamps, istop points to
                     # the last in aseries of repeats
-                    while times_reducedm[it] == burst.stop:
+                    while times_reduced[it] == burst.stop:
                         it += 1
                     out[ib].istop = it - 1
                     stopfound = True

--- a/fretbursts/burstsearch/burstsearchlib.py
+++ b/fretbursts/burstsearch/burstsearchlib.py
@@ -452,7 +452,7 @@ class Bursts(object):
         newbursts.stop = times[self.istop]
         return newbursts
 
-    def recompute_index_expand(self, mask):
+    def recompute_index_expand(self, mask, out=None):
         """Recompute istart and istop from selection `mask` to full timestamps.
 
         This modifies the Bursts object inplace recomputing istart and istop.
@@ -468,16 +468,21 @@ class Bursts(object):
         Arguments:
             mask (bool array): boolean mask defining the timestamps selection
                 on which the old istart and istop were computed.
+            out (None or Bursts): if None (default), do computations on a copy
+                of the current object. Otherwise, modify the `Bursts` object
+                passed (can be used for in-place operations).
 
         Returns:
-            A new Bursts object with recomputed istart/istop.
+            A `Bursts` object with recomputed istart/istop.
         """
+        if out is None:
+            out = self.copy()
         index = np.arange(mask.size, dtype=np.int32)
-        self.istart = index[mask][self.istart]
-        self.istop = index[mask][self.istop]
-        return self
+        out.istart = index[mask][self.istart]
+        out.istop = index[mask][self.istop]
+        return out
 
-    def recompute_index_reduce(self, times_reduced):
+    def recompute_index_reduce(self, times_reduced, out=None):
         """Recompute istart and istop on reduced timestamps `times_reduced`.
 
         This method returns a new Bursts object with same start and stop times
@@ -495,19 +500,23 @@ class Bursts(object):
             times_reduced (array): array of selected timestamps used to
                 compute the new istart and istop. This array needs to be
                 a sub-set of the original timestamps array.
+            out (None or Bursts): if None (default), do computations on a copy
+                of the current object. Otherwise, modify the `Bursts` object
+                passed (can be used for in-place operations).
 
         Returns:
-            A new Bursts object with recomputed istart/istop times.
+            A `Bursts` object with recomputed istart/istop times.
         """
-        newbursts = self.copy()
-        for i, burst in enumerate(newbursts):
+        if out is None:
+            out = self.copy()
+        for i, burst in enumerate(self):
             # The first index ([0]) accesses the tuple returned by nonzero.
             # The second index ([0] or [-1]) accesses the array inside the
             # tuple. THis array can have size > 1 when burst start or stop
             # happens on a repeated timestamp.
-            newbursts[i].istart = np.nonzero(times_reduced == burst.start)[0][0]
-            newbursts[i].istop = np.nonzero(times_reduced == burst.stop)[0][-1]
-        return newbursts
+            out[i].istart = np.nonzero(times_reduced == burst.start)[0][0]
+            out[i].istop = np.nonzero(times_reduced == burst.stop)[0][-1]
+        return out
 
     def and_gate(self, bursts2):
         """From 2 burst arrays return bursts defined as intersection (AND rule).

--- a/fretbursts/burstsearch/burstsearchlib.py
+++ b/fretbursts/burstsearch/burstsearchlib.py
@@ -486,7 +486,7 @@ class Bursts(object):
         out.istop = index[mask][self.istop]
         return out
 
-#    def recompute_index_reduce_slow(self, times_reduced, out=None):
+#    def recompute_index_reduce2(self, times_reduced, out=None):
 #        """Recompute istart and istop on reduced timestamps `times_reduced`.
 #
 #        Extremely inefficient (but very simple!) version of

--- a/fretbursts/burstsearch/burstsearchlib.py
+++ b/fretbursts/burstsearch/burstsearchlib.py
@@ -478,7 +478,7 @@ class Bursts(object):
         return self
 
     def recompute_index_reduce(self, times_reduced):
-        """Recompute istart and istop on reduced timestamps selected by `mask`.
+        """Recompute istart and istop on reduced timestamps `times_reduced`.
 
         This method returns a new Bursts object with same start and stop times
         and recomputed istart and istop. Old istart, istop are assumed to
@@ -501,8 +501,12 @@ class Bursts(object):
         """
         newbursts = self.copy()
         for i, burst in enumerate(newbursts):
-            newbursts[i].istart = np.nonzero(times_reduced == burst.start)[0]
-            newbursts[i].istop = np.nonzero(times_reduced == burst.stop)[0]
+            # The first index ([0]) accesses the tuple returned by nonzero.
+            # The second index ([0] or [-1]) accesses the array inside the
+            # tuple. THis array can have size > 1 when burst start or stop
+            # happens on a repeated timestamp.
+            newbursts[i].istart = np.nonzero(times_reduced == burst.start)[0][0]
+            newbursts[i].istop = np.nonzero(times_reduced == burst.stop)[0][-1]
         return newbursts
 
     def and_gate(self, bursts2):

--- a/fretbursts/burstsearch/burstsearchlib.py
+++ b/fretbursts/burstsearch/burstsearchlib.py
@@ -430,7 +430,7 @@ class Bursts(object):
     ##
     ## Burst manipulation methods
     ##
-    def recompute_times(self, times):
+    def recompute_times(self, times, out=None):
         """Recomputes start, stop times applying index data to `times`.
 
         This method computes burst start, stop using the index of
@@ -443,14 +443,18 @@ class Bursts(object):
 
         Arguments:
             times (array): array of photon timestamps
+            out (None or Bursts): if None (default), do computations on a copy
+                of the current object. Otherwise, modify the `Bursts` object
+                passed (can be used for in-place operations).
 
         Returns:
-            A new Bursts object with recomputed start/stop times.
+            A `Bursts` object with recomputed start/stop times.
         """
-        newbursts = self.copy()
-        newbursts.start = times[self.istart]
-        newbursts.stop = times[self.istop]
-        return newbursts
+        if out is None:
+            out = self.copy()
+        out.start = times[self.istart]
+        out.stop = times[self.istop]
+        return out
 
     def recompute_index_expand(self, mask, out=None):
         """Recompute istart and istop from selection `mask` to full timestamps.

--- a/fretbursts/tests/test_burstlib.py
+++ b/fretbursts/tests/test_burstlib.py
@@ -423,10 +423,14 @@ def test_burst_recompute_index(data):
             d.iter_ph_times(ph_sel=ph_sel),
             d.iter_ph_masks(ph_sel=ph_sel),
             d_sel.mburst, d.mburst):
-        bursts_sel2 = bursts_allph.recompute_index_reduce(times_sel)
-        assert  bursts_sel2 == bursts_sel
+        # Test individual methods
         bursts_allph2 = bursts_sel.recompute_index_expand(mask_sel)
         assert  bursts_allph2 == bursts_allph
+        bursts_sel2 = bursts_allph.recompute_index_reduce(times_sel)
+        assert  bursts_sel2 == bursts_sel
+        # Test round-trip
+        bursts_allph3 = bursts_sel2.recompute_index_expand(mask_sel)
+        assert  bursts_allph3 == bursts_allph
 
 def test_burst_ph_data_functions(data):
     """Tests the functions that operate on per-burst "ph-data".

--- a/fretbursts/tests/test_burstlib.py
+++ b/fretbursts/tests/test_burstlib.py
@@ -405,6 +405,29 @@ def test_burst_istart_iend_size(data):
         counts = bursts.istop - bursts.istart + 1
         assert (counts == bursts.counts).all()
 
+def test_burst_recompute_times(data):
+    """Test Bursts.recompute_times method."""
+    d = data
+    for times, bursts in zip(d.ph_times_m, d.mburst):
+        newbursts = bursts.recompute_times(times)
+        assert newbursts == bursts
+
+def test_burst_recompute_index(data):
+    """Test Bursts.recompute_index_* methods."""
+    d = data
+    ph_sel = Ph_sel(Dex='DAem')
+    d.burst_search(ph_sel=ph_sel, index_all=True)
+    d_sel = d.copy()
+    d_sel.burst_search(ph_sel=ph_sel, index_all=False)
+    for times_sel, mask_sel, bursts_sel, bursts_allph in zip(
+            d.iter_ph_times(ph_sel=ph_sel),
+            d.iter_ph_masks(ph_sel=ph_sel),
+            d_sel.mburst, d.mburst):
+        bursts_sel2 = bursts_allph.recompute_index_reduce(times_sel)
+        assert  bursts_sel2 == bursts_sel
+        bursts_allph2 = bursts_sel.recompute_index_expand(mask_sel)
+        assert  bursts_allph2 == bursts_allph
+
 def test_burst_ph_data_functions(data):
     """Tests the functions that operate on per-burst "ph-data".
     """

--- a/fretbursts/tests/test_burstlib.py
+++ b/fretbursts/tests/test_burstlib.py
@@ -448,6 +448,31 @@ def test_burst_recompute_index(data):
         assert (times_allph[bursts_allph3.istart] == bursts_allph3.start).all()
         assert (times_allph[bursts_allph3.istop] == bursts_allph3.stop).all()
 
+## This test is only used to develop alternative implementations of
+## Bursts.recompute_index_reduce() and is normally disable as it is very slow.
+#def test_burst_recompute_index_reduce(data):
+#    """Test different versions of Bursts.recompute_index_reduce methods.
+#
+#    This test is very slow so it's normally disabled.
+#    """
+#    d = data
+#    ph_sel = Ph_sel(Dex='Aem')
+#    d.burst_search(ph_sel=ph_sel)
+#    d_sel = d.copy()
+#    d_sel.burst_search(ph_sel=ph_sel, index_allph=False)
+#    for times_sel, bursts_sel, times_allph, bursts_allph in zip(
+#            d.iter_ph_times(ph_sel=ph_sel),
+#            d_sel.mburst,
+#            d.iter_ph_times(),
+#            d.mburst):
+#        assert (times_allph[bursts_allph.istart] == bursts_allph.start).all()
+#        assert (times_allph[bursts_allph.istop] == bursts_allph.stop).all()
+#
+#        bursts_sel1 = bursts_allph.recompute_index_reduce(times_sel)
+#        bursts_sel2 = bursts_allph.recompute_index_reduce2(times_sel)
+#        assert  bursts_sel1 == bursts_sel2
+#        assert  bursts_sel == bursts_sel1
+
 def test_burst_ph_data_functions(data):
     """Tests the functions that operate on per-burst "ph-data".
     """

--- a/fretbursts/tests/test_burstlib.py
+++ b/fretbursts/tests/test_burstlib.py
@@ -415,7 +415,7 @@ def test_burst_recompute_times(data):
 def test_burst_recompute_index(data):
     """Test Bursts.recompute_index_* methods."""
     d = data
-    ph_sel = Ph_sel(Dex='DAem')
+    ph_sel = Ph_sel(Dex='Dem')
     d.burst_search(ph_sel=ph_sel, index_allph=True)
     d_sel = d.copy()
     d_sel.burst_search(ph_sel=ph_sel, index_allph=False)
@@ -447,7 +447,6 @@ def test_burst_recompute_index(data):
         assert  bursts_allph3 == bursts_allph2
         assert (times_allph[bursts_allph3.istart] == bursts_allph3.start).all()
         assert (times_allph[bursts_allph3.istop] == bursts_allph3.stop).all()
-
 
 def test_burst_ph_data_functions(data):
     """Tests the functions that operate on per-burst "ph-data".

--- a/fretbursts/tests/test_burstlib.py
+++ b/fretbursts/tests/test_burstlib.py
@@ -416,21 +416,38 @@ def test_burst_recompute_index(data):
     """Test Bursts.recompute_index_* methods."""
     d = data
     ph_sel = Ph_sel(Dex='DAem')
-    d.burst_search(ph_sel=ph_sel, index_all=True)
+    d.burst_search(ph_sel=ph_sel, index_allph=True)
     d_sel = d.copy()
-    d_sel.burst_search(ph_sel=ph_sel, index_all=False)
-    for times_sel, mask_sel, bursts_sel, bursts_allph in zip(
+    d_sel.burst_search(ph_sel=ph_sel, index_allph=False)
+    for times_sel, mask_sel, bursts_sel, times_allph, bursts_allph in zip(
             d.iter_ph_times(ph_sel=ph_sel),
             d.iter_ph_masks(ph_sel=ph_sel),
-            d_sel.mburst, d.mburst):
+            d_sel.mburst,
+            d.iter_ph_times(),
+            d.mburst):
+        assert (times_sel[bursts_sel.istart] == bursts_sel.start).all()
+        assert (times_sel[bursts_sel.istop] == bursts_sel.stop).all()
+
+        assert (times_allph[bursts_allph.istart] == bursts_allph.start).all()
+        assert (times_allph[bursts_allph.istop] == bursts_allph.stop).all()
+
         # Test individual methods
         bursts_allph2 = bursts_sel.recompute_index_expand(mask_sel)
         assert  bursts_allph2 == bursts_allph
+        assert (times_allph[bursts_allph2.istart] == bursts_allph2.start).all()
+        assert (times_allph[bursts_allph2.istop] == bursts_allph2.stop).all()
+
         bursts_sel2 = bursts_allph.recompute_index_reduce(times_sel)
+        assert (times_sel[bursts_sel2.istart] == bursts_sel2.start).all()
+        assert (times_sel[bursts_sel2.istop] == bursts_sel2.stop).all()
         assert  bursts_sel2 == bursts_sel
+
         # Test round-trip
         bursts_allph3 = bursts_sel2.recompute_index_expand(mask_sel)
-        assert  bursts_allph3 == bursts_allph
+        assert  bursts_allph3 == bursts_allph2
+        assert (times_allph[bursts_allph3.istart] == bursts_allph3.start).all()
+        assert (times_allph[bursts_allph3.istop] == bursts_allph3.stop).all()
+
 
 def test_burst_ph_data_functions(data):
     """Tests the functions that operate on per-burst "ph-data".


### PR DESCRIPTION
The three methods:

- Bursts.recompute_times
- Bursts.recompute_index_expand
- Bursts.recompute_index_reduce

were not well tested. The latter one (Bursts.recompute_index_reduce) had only a stub implementation which was wrong.

This PR add tests for these 3 methods, complete the implementation of Bursts.recompute_index_reduce and fixes a bug in Bursts.recompute_times (found through unit tests) which was affecting the burst search when `compact=True` (the default is False) was used. Additionally there are some cleanups and docstring improvements.