### PR TITLE
Fix burst-search with L parameter

### DIFF
--- a/fretbursts/phtools/burstsearch.py
+++ b/fretbursts/phtools/burstsearch.py
@@ -114,14 +114,14 @@ def bsearch_py(times, L, m, T, slice_=None,
             if not above_min_rate_:
                 break
         i_stop = i + m - 2  # index of last ph in burst
-
-        bursts.append((i_start, i_stop, times[i_start], times[i_stop]))
+        if i_stop - i_start + 1 >= L:
+            bursts.append((i_start, i_stop, times[i_start], times[i_stop]))
 
     if above_min_rate_:
         # Correct burst-stop off by 1 when last burst does not finish
         i_start, i_stop, start, stop = bursts.pop()
-        bursts.append((i_start, i_stop + 1,
-                       times[i_start], times[i_stop + 1]))
+        if i_stop - i_start + 1 >= L:
+            bursts.append((i_start, i_stop + 1,times[i_start], times[i_stop + 1]))
 
     bursts = np.array(bursts, dtype='int64')
     if bursts.size > 0:

--- a/fretbursts/phtools/burstsearch.py
+++ b/fretbursts/phtools/burstsearch.py
@@ -121,7 +121,8 @@ def bsearch_py(times, L, m, T, slice_=None,
         # Correct burst-stop off by 1 when last burst does not finish
         i_start, i_stop, start, stop = bursts.pop()
         if i_stop - i_start + 1 >= L:
-            bursts.append((i_start, i_stop + 1,times[i_start], times[i_stop + 1]))
+            bursts.append((i_start, i_stop + 1,
+                           times[i_start], times[i_stop + 1]))
 
     bursts = np.array(bursts, dtype='int64')
     if bursts.size > 0:

--- a/fretbursts/phtools/burstsearch.py
+++ b/fretbursts/phtools/burstsearch.py
@@ -119,10 +119,10 @@ def bsearch_py(times, L, m, T, slice_=None,
 
     if above_min_rate_:
         # Correct burst-stop off by 1 when last burst does not finish
-        i_start, i_stop, start, stop = bursts.pop()
+        i_stop += 1
         if i_stop - i_start + 1 >= L:
-            bursts.append((i_start, i_stop + 1,
-                           times[i_start], times[i_stop + 1]))
+            bursts.pop()
+            bursts.append((i_start, i_stop, times[i_start], times[i_stop]))
 
     bursts = np.array(bursts, dtype='int64')
     if bursts.size > 0:

--- a/fretbursts/phtools/burstsearch_c.pyx
+++ b/fretbursts/phtools/burstsearch_c.pyx
@@ -69,13 +69,13 @@ def bsearch_c(np.int64_t[:] times, np.int16_t L, np.int16_t m,
             in_burst = 0
             i_stop = i + m - 2
             if i_stop - i_start + 1 >= L:
-                        bursts.append((i_start, i_stop,
-                           times[i_start], times[i_stop]))
+                bursts.append((i_start, i_stop,
+                               times[i_start], times[i_stop]))
 
     if in_burst:
         i_stop = i + m - 1
         if i_stop - i_start + 1 >= L:
-                bursts.append((i_start, i_stop, times[i_start], times[i_stop]))
+            bursts.append((i_start, i_stop, times[i_start], times[i_stop]))
 
     return np.array(bursts, dtype='int64')
 

--- a/fretbursts/phtools/burstsearch_c.pyx
+++ b/fretbursts/phtools/burstsearch_c.pyx
@@ -68,12 +68,14 @@ def bsearch_c(np.int64_t[:] times, np.int16_t L, np.int16_t m,
         elif in_burst:
             in_burst = 0
             i_stop = i + m - 2
-            bursts.append((i_start, i_stop,
+            if i_stop - i_start + 1 >= L:
+                        bursts.append((i_start, i_stop,
                            times[i_start], times[i_stop]))
 
     if in_burst:
         i_stop = i + m - 1
-        bursts.append((i_start, i_stop, times[i_start], times[i_stop]))
+        if i_stop - i_start + 1 >= L:
+                bursts.append((i_start, i_stop, times[i_start], times[i_stop]))
 
     return np.array(bursts, dtype='int64')
 

--- a/fretbursts/tests/test_burstlib.py
+++ b/fretbursts/tests/test_burstlib.py
@@ -298,6 +298,12 @@ def test_burst_search_py_cy(data):
     data.burst_search(pure_python=False)
     assert np.all(num_bursts1 == data.num_bursts)
     assert mburst1 == data.mburst
+    data.burst_search(L=30, pure_python=True)
+    mburst1 = [b.copy() for b in data.mburst]
+    num_bursts1 = data.num_bursts
+    data.burst_search(L=30, pure_python=False)
+    assert np.all(num_bursts1 == data.num_bursts)
+    assert mburst1 == data.mburst
 
 def test_burst_search_constant_rates(data):
     """Test python and cython burst search with constant threshold."""
@@ -309,6 +315,17 @@ def test_burst_search_constant_rates(data):
     assert (data.num_bursts > 0).all()
     assert np.all(num_bursts1 == data.num_bursts)
     assert mburst1 == data.mburst
+
+def test_burst_search_L(data):
+    """Test burst search with different L arguments."""
+    data.burst_search(L=10)
+    for bursts in data.mburst:
+        assert (bursts.counts >= 10).all()
+    num_bursts1 = data.num_bursts
+    data.burst_search(L=30)
+    for bursts in data.mburst:
+        assert (bursts.counts >= 30).all()
+    assert np.all(num_bursts1 > data.num_bursts)
 
 def test_burst_search_with_no_bursts(data):
     """Smoke test burst search when some periods have no bursts."""


### PR DESCRIPTION
FRETBursts is ignoring the L parameter during burst search.

In this PR, `burstsearch.py` and `burstsearch_c.pyx` were modified to allow performing burst-search with the threshold `L` in python and cython. 